### PR TITLE
fix: kit system and others

### DIFF
--- a/system-bukkit/src/main/java/br/com/system/bukkit/command/FeedCommand.java
+++ b/system-bukkit/src/main/java/br/com/system/bukkit/command/FeedCommand.java
@@ -28,7 +28,7 @@ public class FeedCommand extends BaseCommand {
         return;
       }
 
-      target.setAllowFlight(!target.getAllowFlight());
+      target.setFoodLevel(20);
 
       if (args.length == 1 || !args[1].equalsIgnoreCase("-s")) {
         system.getExecutor().msg(target, "commands.feed.target-feed", "%player-name%", sender.getName());

--- a/system-bukkit/src/main/java/br/com/system/bukkit/command/KitCommand.java
+++ b/system-bukkit/src/main/java/br/com/system/bukkit/command/KitCommand.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
-import java.util.Map;
 
 public class KitCommand extends BaseCommand {
 
@@ -64,9 +63,9 @@ public class KitCommand extends BaseCommand {
     }
 
     if (!player.hasPermission("system.kit.delay.bypass")
-     && userKit.getNextPickup() > System.currentTimeMillis()) {
+     && userKit.getNextPickup(kit.getDelay()) > System.currentTimeMillis()) {
       plugin.getExecutor().msg(player, "commands.kit.in-delay",
-       "%kit-delay%", TimeFormatter.format(System.currentTimeMillis() - userKit.getNextPickup())
+       "%kit-delay%", TimeFormatter.format(userKit.getNextPickup(kit.getDelay()) - System.currentTimeMillis())
       );
       return;
     }
@@ -79,7 +78,7 @@ public class KitCommand extends BaseCommand {
       return;
     }
 
-    if (!plugin.getSettings().isDropIfFull() && PlayerUtil.getPlayerInventorySpace(player) < kit.getKitCount()) {
+    if (!plugin.getSettings().isDropIfFull() && PlayerUtil.getPlayerInventorySpace(player) < kit.getKitItemsCount()) {
       plugin.getExecutor().msg(player, "commands.kit.space-enough");
       return;
     }
@@ -92,13 +91,8 @@ public class KitCommand extends BaseCommand {
 
     HashMap<Integer, ItemStack> remainingItemMap = player.getInventory().addItem(kit.getItemStacks());
     if (!remainingItemMap.isEmpty()) {
-      for (Map.Entry<Integer, ItemStack> entry : remainingItemMap.entrySet()) {
-        Integer key = entry.getKey();
-        ItemStack value = entry.getValue();
-
-        value.setAmount(key);
-
-        player.getWorld().dropItemNaturally(player.getLocation(), value);
+      for (ItemStack item : remainingItemMap.values()) {
+        player.getWorld().dropItemNaturally(player.getLocation(), item);
       }
 
       plugin.getExecutor().msg(player, "commands.kit.dropped");

--- a/system-bukkit/src/main/java/br/com/system/bukkit/factory/UserFactory.java
+++ b/system-bukkit/src/main/java/br/com/system/bukkit/factory/UserFactory.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public class UserFactory {
 
   public User createUser(UUID id, String name, String display, Location spawnLocation, Location lastLocation) {
-    return new User(id, name, display, spawnLocation, lastLocation, new ArrayList<>(), Instant.now(), Instant.now());
+    return new User(id, name, display, spawnLocation, lastLocation, new ArrayList<>(), new ArrayList<>(), Instant.now(), Instant.now());
   }
 
   public User createUser(Player player) {

--- a/system-bukkit/src/main/java/br/com/system/bukkit/repository/UserKitRepository.java
+++ b/system-bukkit/src/main/java/br/com/system/bukkit/repository/UserKitRepository.java
@@ -52,7 +52,7 @@ public class UserKitRepository implements Repository {
           ps.setString(1, user.getId().toString());
           ps.setString(2, kit.getKitName());
           ps.setInt(3, kit.getPickupCount());
-          ps.setLong(4, kit.getNextPickup());
+          ps.setLong(4, kit.getLastPickup());
           ps.executeUpdate();
         }
       } catch (SQLException exception) {
@@ -70,7 +70,7 @@ public class UserKitRepository implements Repository {
 
         try (PreparedStatement ps = connection.prepareStatement("UPDATE system_users_kits SET pickup_count = ?, last_pickup = ? WHERE kit_name = ? AND id = ?")) {
           ps.setInt(1, kit.getPickupCount());
-          ps.setLong(2, kit.getNextPickup());
+          ps.setLong(2, kit.getLastPickup());
           ps.setString(3, kit.getKitName());
           ps.setString(4, user.getId().toString());
           ps.executeUpdate();

--- a/system-bukkit/src/main/java/br/com/system/bukkit/repository/UserRepository.java
+++ b/system-bukkit/src/main/java/br/com/system/bukkit/repository/UserRepository.java
@@ -121,8 +121,8 @@ public class UserRepository implements Repository {
          "id CHAR(36) NOT NULL, " +
          "name VARCHAR(32) NOT NULL, " +
          "display VARCHAR(64) NOT NULL, " +
-         "spawn_location VARCHAR(128) NOT NULL, " +
-         "last_location VARCHAR(128) NOT NULL, " +
+         "spawn_location VARCHAR(128) NULL, " +
+         "last_location VARCHAR(128) NULL, " +
          "first_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
          "last_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
          "PRIMARY KEY (id)" +
@@ -155,6 +155,7 @@ public class UserRepository implements Repository {
      spawnLocation,
      lastLocation,
      addresses,
+     kits,
      firstAt,
      lastAt
     );

--- a/system-bukkit/src/main/resources/commands.yml
+++ b/system-bukkit/src/main/resources/commands.yml
@@ -114,7 +114,7 @@ commands:
     key: "Feed"
     description: "Sacia sua fome ou de um jogador."
     usage: "&cUse '/feed [jogador]'."
-    alias: ["comida"]
+    alias: ["comida", "fome"]
     permission-setting:
       permission: "system.commands.feed"
       message: "&cVocê não possui permissão para executar esse comando."
@@ -222,7 +222,7 @@ commands:
     key: "Trash"
     description: "Abre uma lixeira virtual."
     usage: "&cUse '/lixeira'."
-    alias: ["lixeira"]
+    alias: ["lixeira", "lixo"]
     permission-setting:
       permission: "system.commands.trash"
       message: "&cVocê não possui permissão para executar esse comando."

--- a/system-core/src/main/java/br/com/system/core/model/kit/Kit.java
+++ b/system-core/src/main/java/br/com/system/core/model/kit/Kit.java
@@ -19,7 +19,7 @@ public class Kit {
 
   private int maxPickups;
 
-  public int getKitCount() {
+  public int getKitItemsCount() {
     return itemStacks.length;
   }
 }

--- a/system-core/src/main/java/br/com/system/core/model/user/User.java
+++ b/system-core/src/main/java/br/com/system/core/model/user/User.java
@@ -36,6 +36,7 @@ public class User extends Identifier {
    Location spawnLocation,
    Location lastLocation,
    List<Address> addresses,
+   List<UserKit> kits,
    Instant firstAt,
    Instant lastAt
   ) {
@@ -44,6 +45,7 @@ public class User extends Identifier {
     this.spawnLocation = spawnLocation;
     this.lastLocation = lastLocation;
     this.addresses = addresses;
+    this.kits = kits;
     this.firstAt = firstAt;
     this.lastAt = lastAt;
   }

--- a/system-core/src/main/java/br/com/system/core/model/user/kit/UserKit.java
+++ b/system-core/src/main/java/br/com/system/core/model/user/kit/UserKit.java
@@ -12,7 +12,7 @@ public class UserKit {
   private int pickupCount;
   private long lastPickup;
 
-  public long getNextPickup() {
-    return System.currentTimeMillis() + lastPickup;
+  public long getNextPickup(long kitDelay) {
+    return lastPickup + kitDelay;
   }
 }


### PR DESCRIPTION
- O delays dos kits não funcionavam corretamente.
- O dropar kit quando o inventario está cheio estava duplicando itens
- O /feed quando executado no console tinha a mesma função do /fly
- Adicionado mais aliases para o comando /trash e /feed